### PR TITLE
Fix redux types

### DIFF
--- a/.changeset/tender-wolves-give.md
+++ b/.changeset/tender-wolves-give.md
@@ -1,0 +1,5 @@
+---
+'@withease/redux': patch
+---
+
+Fixed public types generation

--- a/packages/redux/index.ts
+++ b/packages/redux/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/packages/redux/project.json
+++ b/packages/redux/project.json
@@ -7,7 +7,7 @@
     "pack": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node tools/scripts/typepack.mjs --package redux --filename src/index.d.ts"
+        "command": "node tools/scripts/typepack.mjs --package redux"
       },
       "dependsOn": [
         {
@@ -20,7 +20,7 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/packages/redux",
-        "entryFile": "packages/redux/src/index.ts",
+        "entryFile": "packages/redux/index.ts",
         "tsConfig": "packages/redux/tsconfig.lib.json",
         "project": "packages/redux/package.json",
         "format": ["esm", "cjs"],


### PR DESCRIPTION
`typepack.mjs` could not generate proper types for any project structure other than `<package root>/index.ts`