### PR TITLE
`@withease/redux` - async setup

### DIFF
--- a/.changeset/thick-terms-hear.md
+++ b/.changeset/thick-terms-hear.md
@@ -2,7 +2,7 @@
 '@withease/redux': minor
 ---
 
-This PR adds a new overload for the `createReduxIntegration` - without explicit `reduxStore`, which allows you to pass the Store via `setup` event later.
+Add a new overload for the `createReduxIntegration` - without explicit `reduxStore`, which allows you to pass the Store via `setup` _Event_ later.
 
 This helps to avoid dependency cycles, but at a cost:
 The type support for `reduxInterop.$state` will be slightly worse and `reduxInterop.dispatch` will be no-op (and will show warnings in console) until interop object is provided with Redux Store.

--- a/.changeset/thick-terms-hear.md
+++ b/.changeset/thick-terms-hear.md
@@ -2,4 +2,7 @@
 '@withease/redux': minor
 ---
 
-Added "Async Setup" feature
+This PR adds a new overload for the `createReduxIntegration` - without explicit `reduxStore`, which allows you to pass the Store via `setup` event later.
+
+This helps to avoid dependency cycles, but at a cost:
+The type support for `reduxInterop.$state` will be slightly worse and `reduxInterop.dispatch` will be no-op (and will show warnings in console) until interop object is provided with Redux Store.

--- a/.changeset/thick-terms-hear.md
+++ b/.changeset/thick-terms-hear.md
@@ -1,0 +1,5 @@
+---
+'@withease/redux': minor
+---
+
+Added "Async Setup" feature

--- a/apps/website/docs/.vitepress/config.js
+++ b/apps/website/docs/.vitepress/config.js
@@ -58,7 +58,13 @@ export default defineConfig({
         { text: 'Get Started', link: '/i18next/' },
         { text: 'Release policy', link: '/i18next/releases' },
       ]),
-      ...createSidebar('redux', [{ text: 'Get Started', link: '/redux/' }]),
+      ...createSidebar('redux', [
+        { text: 'Get Started', link: '/redux/' },
+        {
+          text: 'Migrating from Redux to Effector',
+          link: '/magazine/migration_from_redux',
+        },
+      ]),
       ...createSidebar('web-api', [
         { text: 'Get Started', link: '/web-api/' },
         {

--- a/apps/website/docs/magazine/migration_from_redux.md
+++ b/apps/website/docs/magazine/migration_from_redux.md
@@ -50,7 +50,7 @@ export const reduxInterop = createReduxIntegration({
 
 Note, that overload of the `createReduxIntegration` with explicit `reduxStore` allows for better Typescript type inference, but also might result in cyclic dependencies.
 
-In case if you encountered this issue, you can use "async" setup of the `reduxInterop` object, but will lead to `null`-checks later, because in that case there is a possibility, that Redux Store is not initialized yet, while `reduxInterop` object is already in use.
+In case if you encountered this issue, you can use "async" setup of the `reduxInterop` object, but it will lead to `null`-checks later, because in that case there is a possibility, that Redux Store is not initialized yet, while `reduxInterop` object is already in use.
 
 See [the package documentation](/redux/) for more details.
 

--- a/apps/website/docs/magazine/migration_from_redux.md
+++ b/apps/website/docs/magazine/migration_from_redux.md
@@ -46,7 +46,36 @@ export const reduxInterop = createReduxIntegration({
 });
 ```
 
-☝️ Notice, how explicit `setup` event is required to initialize the interoperability. Usually it would be an `appStarted` event or any other "app's lifecycle" event.
+#### Avoiding ependency cycles
+
+Note, that overload of the `createReduxIntegration` with explicit `reduxStore` allows for better Typescript type inference, but also might result in cyclic dependencies.
+
+In case if you encountered this issue, you can use "async" setup of the `reduxInterop` object, but will lead to `null`-checks later, because in that case there is a possibility, that Redux Store is not initialized yet, while `reduxInterop` object is already in use.
+
+See [the package documentation](/redux/) for more details.
+
+```ts
+// src/shared/redux-interop
+export const startReduxInterop = createEvent<ReduxStore>();
+export const reduxInterop = createReduxIntegration({
+  setup: startReduxInterop,
+});
+
+// src/entrypoint.ts
+import { startReduxInterop } from 'shared/redux-interop';
+
+const myReduxStore = configureStore({
+  // ...
+});
+
+startReduxInterop(myReduxStore);
+```
+
+☝️ This would allow you to access `reduxInterop` object and avoid possible dependency cycles, if `reduxInterop` is being imported somewhere along with some reducers or middlewares.
+
+#### Explicit `setup`
+
+Notice, how explicit `setup` event is required to initialize the interoperability. Usually it would be an `appStarted` event or any other "app's lifecycle" event.
 
 You can read more about this best-practice [in the "Explicit start of the app" article](/magazine/explicit_start).
 
@@ -62,6 +91,7 @@ export const appStarted = createEvent();
 And then call this event in the point, which corresponds to "start of the app" - usually this is somewhere near the render.
 
 ```tsx
+// src/entrypoint.ts
 import { appStarted } from 'root/shared/app-lifecycle';
 
 appStarted();

--- a/apps/website/docs/magazine/migration_from_redux.md
+++ b/apps/website/docs/magazine/migration_from_redux.md
@@ -46,7 +46,7 @@ export const reduxInterop = createReduxIntegration({
 });
 ```
 
-#### Avoiding ependency cycles
+#### Avoiding dependency cycles
 
 Note, that overload of the `createReduxIntegration` with explicit `reduxStore` allows for better Typescript type inference, but also might result in cyclic dependencies.
 

--- a/apps/website/docs/redux/index.md
+++ b/apps/website/docs/redux/index.md
@@ -52,6 +52,37 @@ Explicit `setup` event is required to initialize the interoperability. Usually i
 
 You can read more about this practice [in the "Explicit start of the app" article](/magazine/explicit_start).
 
+#### Async initialization
+
+You can also defer interop object initialization and Redux Store creation in time.
+
+The `createReduxIntegration` overload without explicit `reduxStore` allows you to pass the Store via `setup` event later.
+
+```ts
+// src/shared/redux-interop
+export const startReduxInterop = createEvent<ReduxStore>();
+export const reduxInterop = createReduxIntegration({
+ setup: startReduxInterop,
+})
+
+// src/entrypoint.ts
+import { startReduxInterop } from 'shared/redux-interop';
+
+const myReduxStore = configureStore({
+  // ...
+});
+
+startReduxInterop(myReduxStore)
+// or, if you use the Fork API
+allSettled(startReduxInterop, {
+  scope: clientScope,
+  params: myReduxStore,
+})
+```
+In that case the type support for `reduxInterop.$state` will be slightly worse and `reduxInterop.dispatch` will be no-op (and will show warnings in console) until interop object is provided with Redux Store.
+
+☝️ This is useful, if your project has cyclic dependencies.
+
 ### Interoperability object
 
 Redux Interoperability object provides few useful APIs.

--- a/apps/website/docs/redux/index.md
+++ b/apps/website/docs/redux/index.md
@@ -52,9 +52,9 @@ Explicit `setup` event is required to initialize the interoperability. Usually i
 
 You can read more about this practice [in the "Explicit start of the app" article](/magazine/explicit_start).
 
-#### Async initialization
+#### Async setup
 
-You can also defer interop object initialization and Redux Store creation in time.
+You can also defer interop object initialization and Redux Store creation.
 
 The `createReduxIntegration` overload without explicit `reduxStore` allows you to pass the Store via `setup` event later.
 

--- a/apps/website/docs/redux/index.md
+++ b/apps/website/docs/redux/index.md
@@ -62,8 +62,8 @@ The `createReduxIntegration` overload without explicit `reduxStore` allows you t
 // src/shared/redux-interop
 export const startReduxInterop = createEvent<ReduxStore>();
 export const reduxInterop = createReduxIntegration({
- setup: startReduxInterop,
-})
+  setup: startReduxInterop,
+});
 
 // src/entrypoint.ts
 import { startReduxInterop } from 'shared/redux-interop';
@@ -72,13 +72,14 @@ const myReduxStore = configureStore({
   // ...
 });
 
-startReduxInterop(myReduxStore)
+startReduxInterop(myReduxStore);
 // or, if you use the Fork API
 allSettled(startReduxInterop, {
   scope: clientScope,
   params: myReduxStore,
-})
+});
 ```
+
 In that case the type support for `reduxInterop.$state` will be slightly worse and `reduxInterop.dispatch` will be no-op (and will show warnings in console) until interop object is provided with Redux Store.
 
 ☝️ This is useful, if your project has cyclic dependencies.

--- a/packages/redux/src/lib/redux.spec.ts
+++ b/packages/redux/src/lib/redux.spec.ts
@@ -301,6 +301,15 @@ describe('@withease/redux', () => {
       expect($test.getState()).toEqual('');
     });
 
+    describe('Async Interop API object initialization', () => {
+      test('Should allow not to pass reduxStore', () => {
+        const setup = createEvent<any>();
+        const interop = createReduxIntegration({ setup });
+
+        expect(interop.$reduxStore.getState()).toBeUndefined();
+      });
+    });
+
     test('Should support redux-thunks', async () => {
       const testSlice = createSlice({
         name: 'test',

--- a/packages/redux/src/lib/redux.spec.ts
+++ b/packages/redux/src/lib/redux.spec.ts
@@ -315,24 +315,27 @@ describe('@withease/redux', () => {
         expect(scope.getState(interop.$state)).toBe(null);
       });
 
-      test('Should complain, if dispatch is called before store setup', () => {
-        const setup = createEvent<any>();
-        const interop = createReduxIntegration({ setup });
-
+      test('Should complain, if dispatch is called before store setup', async () => {
         const spy = vi.spyOn(console, 'error').mockImplementation(() => {
           // ok
         });
 
-        interop.dispatch({ type: 'test' });
+        const setup = createEvent<any>();
+        const interop = createReduxIntegration({ setup });
 
-        expect(spy).toHaveBeenCalled();
-        expect(spy.mock.calls.map((x) => x[0])).toMatchInlineSnapshot();
+        interop.dispatch({ type: 'test' });
 
         const scope = fork();
 
-        allSettled(interop.dispatch, { scope, params: { type: 'test' } });
+        await allSettled(interop.dispatch, { scope, params: { type: 'test' } });
 
-        expect(spy.mock.calls.map((x) => x[0])).toMatchInlineSnapshot();
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls.map((x) => x[0])).toMatchInlineSnapshot(`
+          [
+            [Error: reduxStore must be provided and should be a Redux store],
+            [Error: reduxStore must be provided and should be a Redux store],
+          ]
+        `);
 
         spy.mockRestore();
       });

--- a/packages/redux/src/lib/redux.ts
+++ b/packages/redux/src/lib/redux.ts
@@ -32,6 +32,58 @@ export function createReduxIntegration<
   // eslint-disable-next-line @typescript-eslint/ban-types
   Ext extends {} = {}
 >(config: {
+  setup: Unit<ReduxStore<State, Act, Ext>>;
+}): {
+  /**
+   * Effector store containing the Redux store
+   *
+   * You can use it to substitute Redux store instance, while writing tests via Effector's Fork API
+   * @example
+   * ```
+   * const scope = fork({
+   *  values: [
+   *   [reduxInterop.$reduxStore, reduxStoreMock]
+   *  ]
+   * })
+   * ```
+   */
+  $reduxStore: StoreWritable<null | ReduxStore<State, Act, Ext>>;
+  /**
+   * Effector's event, which will trigger Redux store dispatch
+   *
+   * @example
+   * ```
+   * const updateName = reduxInterop.dispatch.prepend((name: string) => updateNameAction(name));
+   * ```
+   */
+  dispatch: Effect<Act | AnyThunkLikeThing, unknown, Error>;
+  /**
+   * Effector store containing the state of the Redux store
+   *
+   * You can use it to subscribe to the Redux store state changes in Effector
+   * @example
+   * ```
+   * const $userName = combine(reduxInterop.$state, state => state.user.name)
+   * ```
+   */
+  $state: Store<null | (State & Ext)>;
+};
+/**
+ *
+ * Utility function to create an Effector API to interact with Redux store,
+ * useful for cases like soft migration from Redux to Effector.
+ *
+ * @param config - interop config
+ * @param config.reduxStore - a redux store
+ * @param config.setup - effector unit which will setup subscription to the store
+ * @returns Interop API object
+ */
+export function createReduxIntegration<
+  State = unknown,
+  Act extends Action = { type: string; [k: string]: unknown },
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Ext extends {} = {}
+>(config: {
   reduxStore: ReduxStore<State, Act, Ext>;
   // We don't care about the type of the setup unit here
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,7 +122,16 @@ export function createReduxIntegration<
    * ```
    */
   $state: Store<State & Ext>;
-} {
+};
+export function createReduxIntegration<
+  State = unknown,
+  Act extends Action = { type: string; [k: string]: unknown },
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Ext extends {} = {}
+  // Implementation type is `(any) => any`, so TS doesn't complain about overloads being "incompatible"
+  // We do that, because they are incompatible, but that is for a reason - those are intended for different use-cases
+  // e.g. explicit `reduxStore` overload can just infer the types right away + expect that the store and the state are always available
+>(config: any): any {
   const { reduxStore, setup } = config;
   if (!is.unit(setup)) {
     throw new Error('setup must be an effector unit');
@@ -84,7 +145,7 @@ export function createReduxIntegration<
     throw new Error('reduxStore must be provided and should be a Redux store');
   }
 
-  const $reduxStore = createStore(reduxStore, {
+  const $reduxStore = createStore(reduxStore ?? null, {
     serialize: 'ignore',
     name: 'redux/$reduxStore',
   });

--- a/packages/redux/src/lib/redux.ts
+++ b/packages/redux/src/lib/redux.ts
@@ -152,9 +152,22 @@ export function createReduxIntegration<
     name: 'redux/$reduxStore',
   });
 
+  if (!reduxStore) {
+    /**
+     * If no `reduxStore` was provided in the initial config,
+     * then this is an async setup case
+     *
+     * So `reduxStore` will be provided by the `setup` event
+     */
+    sample({
+      clock: setup,
+      target: $reduxStore,
+    });
+  }
+
   const stateUpdated = createEvent<State & Ext>();
 
-  const $state = createStore<State & Ext>(reduxStore.getState() ?? null, {
+  const $state = createStore<State & Ext>(reduxStore?.getState() ?? null, {
     serialize: 'ignore',
     name: 'redux/$state',
     skipVoid: false,

--- a/packages/redux/src/lib/redux.ts
+++ b/packages/redux/src/lib/redux.ts
@@ -140,6 +140,13 @@ export function createReduxIntegration<
     throw new Error('setup must be an effector unit');
   }
 
+  if (reduxStore) {
+    /**
+     * Only assert `reduxStore`, if it was provided explicitly
+     */
+    assertReduxStore(reduxStore);
+  }
+
   const $reduxStore = createStore(reduxStore ?? null, {
     serialize: 'ignore',
     name: 'redux/$reduxStore',


### PR DESCRIPTION
This PR adds a new overload for the `createReduxIntegration` - without explicit `reduxStore`, which allows you to pass the Store via `setup` event later.

```ts
// src/shared/redux-interop
export const startReduxInterop = createEvent<ReduxStore>();
export const reduxInterop = createReduxIntegration({
 setup: startReduxInterop,
})

// src/entrypoint.ts
import { startReduxInterop } from 'shared/redux-interop';

const myReduxStore = configureStore({
  // ...
});

startReduxInterop(myReduxStore)
// or, if you use the Fork API
allSettled(startReduxInterop, {
  scope: clientScope,
  params: myReduxStore,
})
```
In that case the type support for `reduxInterop.$state` will be slightly worse and `reduxInterop.dispatch` will be no-op (and will show warnings in console) until interop object is provided with Redux Store.

☝️ This is useful, if your project has cyclic dependencies.